### PR TITLE
I added a CSS fix to correct inconsistent styling of the login form errors (errors will all be red now).

### DIFF
--- a/suit/templates/registration/login.html
+++ b/suit/templates/registration/login.html
@@ -42,7 +42,7 @@
             <form action="{{ app_path }}" method="post" id="login-form"><div class="hide">{% csrf_token %}</div>
                 <div class="form-row control-group{% if not form.this_is_the_login_form.errors and form.username.errors %} error{% endif %}">
                     <label for="id_username" class="control-label required">{% trans 'Username' %}:</label> {{ form.username }}
-                  {% if not form.this_is_the_login_form.errors and form.username.errors %}<p class="help-block">{{ form.username.errors }}</p>{% endif %}
+                  {% if not form.this_is_the_login_form.errors and form.username.errors %}<div class="help-block">{{ form.username.errors }}</div>{% endif %}
                 </div>
                 <div class="form-row control-group{% if not form.this_is_the_login_form.errors and form.password.errors %} error{% endif %}">
                     <label for="id_password" class="control-label required">{% trans 'Password' %}:</label> {{ form.password }}


### PR DESCRIPTION
![Screen Shot 2013-02-25 at 8 46 49 PM](https://f.cloud.github.com/assets/482775/195015/51be78ca-7fd0-11e2-96f9-e711a4699988.png)
