### PR TITLE
Fix for issue #68

### DIFF
--- a/suit/templatetags/suit_list.py
+++ b/suit/templatetags/suit_list.py
@@ -120,7 +120,7 @@ def suit_list_filter_select(cl, spec):
                 value = query_parts[key][0]
                 matched_key = key
             elif key.startswith(
-                            field_key + '__') or '__' + field_key + '__' in key:
+                            field_key + '__') or '__' + field_key in key:
                 value = query_parts[key][0]
                 matched_key = key
 


### PR DESCRIPTION
Based on the demo site in FF, Chrome and Safari none of the list filters seem to work.

Steps to reproduce:
1) Go to http://djangosuit.com/admin/examples/country/
2) Select Africa in the Continent drop down
3) Press Search

Expected:
List to be filtered by Continent=Africa

Actual:
List is not filtered

I believe the issued is related to the way the code is populating the "name" and the "value" for each option

The following patch should fix it
