### PR TITLE
Consider using target=_blank for models as well

### DIFF
--- a/suit/templates/suit/menu.html
+++ b/suit/templates/suit/menu.html
@@ -25,7 +25,7 @@
               <ul>
                 {% for model in app.models %}
                   <li{{ model.is_active|yesno:' class=active,' }}>
-                    <a href="{{ model.url }}">{{ model.label }}</a></li>
+                    <a href="{{ model.url }}"{{ model.blank|yesno:' target=_blank,' }}>{{ model.label }}</a></li>
                 {% endfor %}
               </ul>
             {% endif %}


### PR DESCRIPTION
I think is useful to have target="_blank" for models too, e.g.:
# This is a sample from MENU configuration:

'models': [
             'core.proxyservice',
             'core.dnsservice',
             'core.servicecategory',
             {'label': 'Sandbox',
              # 'url': 'javascript:window.open("/console/sandbox_preview/","_blank")',
              'url': '/console/sandbox_preview/',
              'blank': True},
]
