### PR TITLE
Fix inline template Django 1.6b4 compatibility issue

### DIFF
--- a/suit/templates/admin/edit_inline/stacked.html
+++ b/suit/templates/admin/edit_inline/stacked.html
@@ -13,8 +13,7 @@
   {% for fieldset in inline_admin_form %}
     {% include "admin/includes/fieldset.html" %}
   {% endfor %}
-  {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
   {{ inline_admin_form.fk_field.field }}
 </div>{% endfor %}
 </div>

--- a/suit/templates/admin/edit_inline/tabular.html
+++ b/suit/templates/admin/edit_inline/tabular.html
@@ -31,8 +31,7 @@
               <td{% if field.field.name %} class="field-{{ field.field.name }}{{ field.field.errors|yesno:' control-group error,' }}{{ field.field.errors|yesno:' control-group error,' }}"{% endif %}>
 
               {% if forloop.parentloop.first %}
-                {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-                {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+                {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
                 {{ inline_admin_form.fk_field.field }}
                 {% spaceless %}
                   {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
In the Django 1.6 beta, in `django.contrib.admin.helpers.InlineAdminForm` the function `has_auto_field` has been renamed to `needs_explicit_pk_field`. This causes the `TabularInline` and `StackedInline` to render incorrectly leading to a KeyDictError when saving records.

The error can be fixed by replacing `has_auto_field` with `needs_explicit_pk_field` in the templates: `templates/admin/edit_inline/stacked.html` and `templates/admin/edit_inline/tabular.html`

My modification is based on a solution by rhunwicks. For comparison see: https://github.com/riccardo-forina/django-admin-bootstrapped/issues/58
