### PR TITLE
Remove trans template tag from output of admin filter choice

### DIFF
--- a/suit/templates/admin/filter.html
+++ b/suit/templates/admin/filter.html
@@ -2,7 +2,7 @@
 <select data-name="{{ field_name }}" class="auto-width search-filter" style="max-width: 200px">
   {% for choice in choices %}
     {% if forloop.first %}
-      <option value="">{% trans title|capfirst %}</option>
+      <option value="">{{ title|capfirst }}</option>
       <option value="">---</option>
     {% else %}
       <option{% if choice.additional %} data-additional="{{ choice.additional }}"{% endif %} data-name="{{ choice.name }}" value="{{ choice.val }}" {{ choice.selected|yesno:' selected="selected",' }}>{{ choice.display }}</option>


### PR DESCRIPTION
The django contrib admin uses: `{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}`
whereas django-suit uses: `{% trans title|capfirst %}`

It seems to me that an attempt to translate the title is only attempted in the django-suit case. The django contrib admin just translates the context "By [...]" but not the filter title itself.

The current state of the django-suit template results in a DjangoUnicodeDecodeError when the filter title contains letters like "å", "ä" and "ö" (I'm not completely certain why this is).
