### PR TITLE
Add all original sites to menu with record "sites"

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -81,9 +81,12 @@ class Menu(object):
             raise TypeError('Django Suit MENU config parameter must be '
                             'tuple or list. Got %s' % repr(config))
         for app in config:
-            app = self.make_app(app)
-            if app:
-                menu.append(app)
+            if app == 'sites':
+                menu += self.make_menu_from_native_only()
+            else:
+                app = self.make_app(app)
+                if app:
+                    menu.append(app)
 
         return menu
 


### PR DESCRIPTION
I've found the record 'sites' in the docs(http://django-suit.readthedocs.org/en/develop/configuration.html#id1), but seems it doesn't work