### PR TITLE
added edit links for admin inline forms

### DIFF
--- a/suit/templates/admin/edit_inline/stacked.html
+++ b/suit/templates/admin/edit_inline/stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n admin_static suit_tags %}
 <div class="inline-group {{ inline_admin_formset.opts.suit_classes }}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
 {{ inline_admin_formset.formset.management_form }}
@@ -8,6 +8,7 @@
   <h3><b>{{ inline_admin_formset.opts.verbose_name|title }}:</b>&nbsp;<span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}{% if not forloop.first and forloop.last %}#{{ forloop.counter }}{% endif %}{% endif %}</span>
     {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
     {% if inline_admin_formset.formset.can_delete and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
+    {% if inline_admin_formset.opts.suit_edit_link and inline_admin_form.original and inline_admin_form.original|admin_url %}<a href="{{ inline_admin_form.original|admin_url }}">Edit</a>{% endif %}
   </h3>
   {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
   {% for fieldset in inline_admin_form %}

--- a/suit/templates/admin/edit_inline/tabular.html
+++ b/suit/templates/admin/edit_inline/tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_modify %}
+{% load i18n admin_static admin_modify suit_tags %}
 <div class="inline-group {{ inline_admin_formset.opts.suit_classes }}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}
@@ -14,6 +14,7 @@
          </th>
        {% endif %}
      {% endfor %}
+     {% if inline_admin_formset.opts.suit_edit_link %}<th>{% trans "Edit" %}</th>{% endif %}
      {% if inline_admin_formset.formset.can_delete %}<th>{% trans "Delete?" %}</th>{% endif %}
      </tr></thead>
 
@@ -60,6 +61,7 @@
             {% endfor %}
           {% endfor %}
         {% endfor %}
+        {% if inline_admin_formset.opts.suit_edit_link %}<td>{% if inline_admin_form.original and inline_admin_form.original|admin_url %}<a href="{{ inline_admin_form.original|admin_url }}">Edit</a>{% endif %}</td>{% endif %}
         {% if inline_admin_formset.formset.can_delete %}
           <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
         {% endif %}

--- a/suit/templatetags/suit_tags.py
+++ b/suit/templatetags/suit_tags.py
@@ -64,4 +64,7 @@ def field_contents_foreign_linked(admin_field):
 @register.filter
 def admin_url(obj):
     info = (obj._meta.app_label, obj._meta.module_name)
-    return reverse("admin:%s_%s_change" % info, args=[obj.pk])
+    try:
+        return reverse("admin:%s_%s_change" % info, args=[obj.pk])
+    except NoReverseMatch:
+        return None


### PR DESCRIPTION
Hi,

since nested inlines are not available I made a little workaround for this. Inline forms that are associated with an existing model instance have now a little "edit" link that leads to it's admin page.

![edit_link_stacked](https://f.cloud.github.com/assets/1387322/1797665/4c24eb68-6aff-11e3-8508-b1f8adc54b4b.png)

![edit_link_tabular](https://f.cloud.github.com/assets/1387322/1797666/5706e1d0-6aff-11e3-97ee-e01775098981.png)

How to setup:

Just add suit_edit_link = _True_ to the properties of the inline admin class.

Maybe this can be made a bit more stylish, but I am not very well at designing things :-P
