### PR TITLE
Remove unknown variable: `onclick_attrib`

### DIFF
--- a/suit/templates/admin/cms/page/plugin_change_form.html
+++ b/suit/templates/admin/cms/page/plugin_change_form.html
@@ -125,7 +125,7 @@
  
 </div>
 <span class="plugin-submit-row"{% if is_popup %} style="overflow: auto;"{% endif %}>
-	<input type="submit" style="float:none;" name="_save" class="btn btn-info" value="{% trans "Save" %}" {{ onclick_attrib }}/>
+	<input type="submit" style="float:none;" name="_save" class="btn btn-info" value="{% trans "Save" %}" />
 	<input type="submit" style="margin-left: 8px;" value="{% trans "Cancel" %}" name="_cancel" class="btn cancel-btn">
 </span>
 </form>

--- a/suit/templates/admin/page_submit_line.html
+++ b/suit/templates/admin/page_submit_line.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <div class="submit-row clearfix">
-  {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save" {{ onclick_attrib }}>{% trans 'Save' %}</button>{% endif %}
-  {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high" {{ onclick_attrib }}>{% trans 'Save and continue editing' %}</button>{% endif %}
-  {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn" {{ onclick_attrib }}>{% trans 'Save as new' %}</button>{%endif%}
-  {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn" {{ onclick_attrib }} >{% trans 'Save and add another' %}</button>{% endif %}
+  {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
+  {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>{% endif %}
+  {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>{%endif%}
+  {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>{% endif %}
 
   {% if show_delete_link %}<a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
   {% endif %}

--- a/suit/templates/admin/submit_line.html
+++ b/suit/templates/admin/submit_line.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <div class="submit-row clearfix">
-  {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save" {{ onclick_attrib }}>{% trans 'Save' %}</button>{% endif %}
-  {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high" {{ onclick_attrib }}>{% trans 'Save and continue editing' %}</button>{% endif %}
-  {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn" {{ onclick_attrib }}>{% trans 'Save as new' %}</button>{%endif%}
-  {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn" {{ onclick_attrib }} >{% trans 'Save and add another' %}</button>{% endif %}
+  {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
+  {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>{% endif %}
+  {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>{%endif%}
+  {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>{% endif %}
 
   {% if show_delete_link %}<a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
   {% endif %}


### PR DESCRIPTION
This has been removed in Django 1.4-1693 (commit gd7b49f5).

When using TEMPLATE_STRING_IF_INVALID, this causes an error.
