### PR TITLE
Update form_tabs.rst

### DIFF
--- a/docs/form_tabs.rst
+++ b/docs/form_tabs.rst
@@ -34,14 +34,14 @@ Example
 
         fieldsets = [
             (None, {
-                'classes': ('suit-tab suit-tab-general',),
+                'classes': ('suit-tab', 'suit-tab-general',),
                 'fields': ['name', 'continent',]
             }),
             ('Statistics', {
-                'classes': ('suit-tab suit-tab-general',),
+                'classes': ('suit-tab', 'suit-tab-general',),
                 'fields': ['area', 'population']}),
             ('Architecture', {
-                'classes': ('suit-tab suit-tab-cities',),
+                'classes': ('suit-tab', 'suit-tab-cities',),
                 'fields': ['architecture']}),
         ]
 


### PR DESCRIPTION
Edited Lines 37,41,44 so each tab is a single string object rather than a whole. When whole and no `suit_form_includes` is given (probably) the tabs wont hide the first tab (e.g. when in cities, the contents of general will be on the bottom as an inline form and not hidden) The edit solves this issue.
