### PR TITLE
Fixed exception when menu config is Unicode

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -3,7 +3,13 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse, resolve
-from django.utils import six
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    # For Django < 1.4.2
+    string_types = basestring,
+
 import warnings
 from suit.config import get_config
 
@@ -108,7 +114,7 @@ class Menu(object):
     def make_app(self, app_def):
         if isinstance(app_def, dict):
             app = app_def.copy()
-        elif isinstance(app_def, six.string_types):
+        elif isinstance(app_def, string_types):
             if app_def == '-':
                 app = self.make_separator()
             else:
@@ -247,7 +253,7 @@ class Menu(object):
     def make_model(self, model_def, app_name):
         if isinstance(model_def, dict):
             model = model_def.copy()
-        elif isinstance(model_def, six.string_types):
+        elif isinstance(model_def, string_types):
             model = self.make_model_from_native(model_def, app_name)
         else:
             raise TypeError('MENU list item must be string or dict. Got %s'
@@ -448,7 +454,7 @@ class Menu(object):
             if isinstance(order, (tuple, list)):
                 app_name = order[0]
                 models_order = order[1] if len(order) > 1 else None
-                if isinstance(app_name, six.string_types):
+                if isinstance(app_name, string_types):
                     new_app['app'] = app_name
                 elif isinstance(app_name, (tuple, list)):
                     mapping = ('label', 'url', 'icon', 'permissions')
@@ -457,7 +463,7 @@ class Menu(object):
                 if models_order and isinstance(models_order, (tuple, list)):
                     models = []
                     for model in models_order:
-                        if isinstance(model, six.string_types):
+                        if isinstance(model, string_types):
                             models.append({'model': model})
                         elif isinstance(model, (list, tuple)):
                             mapping = ('label', 'url', 'permissions')


### PR DESCRIPTION
If the menu config is Unicode (e.g. `from __future__ import unicode_literals` or `u'string'`), the Suit menu will trigger an exception. Tested on Python 2.7 with Django 1.6.
