### PR TITLE
fix NoReverseMatch exception with Django 1.7b2

### DIFF
--- a/suit/templates/admin/object_history.html
+++ b/suit/templates/admin/object_history.html
@@ -6,7 +6,7 @@
 <div class="breadcrumb">
   <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
     <span class="divider">&raquo;</span></li>
-    <li><a href="{% url 'admin:app_list' app_label=app_label %}">{{ app_label|capfirst|escape }}</a>
+    <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a>
       <span class="divider">&raquo;</span></li>
     <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ module_name }}</a>
       <span class="divider">&raquo;</span></li>


### PR DESCRIPTION
The object history view in Django 1.7b2 crashed with a `NoReverseMach`  exception:
`Reverse for 'app_list' with arguments '()' and keyword arguments '{u'app_label': ''}' not found.`
I guess this is due to:
https://github.com/django/django/commit/ba60fcbcf7645afd82f3135ecb56562f8a9c9824
