### PR TITLE
Fixed issue where SortableGenericInlines would break whenever adding blank inline forms

### DIFF
--- a/suit/static/suit/js/sortables.js
+++ b/suit/static/suit/js/sortables.js
@@ -103,9 +103,13 @@
 
         });
 
-        // Filters out unchanged selects and sortable field itself
+        // Filters out unchanged checkboxes, selects and sortable field itself
         function filter_unchanged(i, input) {
-            if (input.type == 'select-one' || input.type == 'select-multiple') {
+            if (input.type == 'checkbox') {
+                if (input.defaultChecked == input.checked) {
+                    return false;
+                }
+            } else if (input.type == 'select-one' || input.type == 'select-multiple') {
                 var options = input.options, option;
                 for (var j = 0; j < options.length; j++) {
                     option = options[j];


### PR DESCRIPTION
This is because inline fieldset names append the names of the generic relation fields as defined in models.py. For instance, instead of being called "model_set-n-field" they'd be called
"app-model-content_type-object_id-n-field" reflecting the names of the generic type and id fields. I replaced the string split on '-' with a regexp split that looks for the -n- pattern instead.

This appears to work in Chrome for both regular and generic relations.
