### PR TITLE
SortableStackedInlineBase fails if the `fields` is defined as a tuple

### DIFF
--- a/suit/admin.py
+++ b/suit/admin.py
@@ -91,8 +91,15 @@ class SortableStackedInlineBase(SortableModelAdminBase):
             for line in fieldset:
                 if not line or not isinstance(line, dict):
                     continue
-
+                
                 fields = line.get('fields')
+                
+                # Some use tuples for fields however they are immutable
+                assert isinstance(fields, tuple), "The fields attribute of your " \
+                                                  "Inline is a tuple. This must be " \
+                                                  "list as we may need to modify " \
+                                                  "it and tuples are immutable."
+                
                 if self.sortable in fields:
                     fields.remove(self.sortable)
 


### PR DESCRIPTION
`SortableStackedInlineBase` fails if the `fields` is defined as a tuple in an admin.py instead of a list (both tuples and lists are acceptable in admin.py).  Suit failed on trying to use `remove()` on an immutable tuple (because it doesn't exist in tuples).

PR puts in an assert to make sure we are not dealing with a tuple and at least give direction on how to fix.

```
File "/usr/local/lib/python2.7/dist-packages/django/contrib/admin/options.py" in get_formset
  1,600.             fields = flatten_fieldsets(self.get_fieldsets(request, obj))
File "/usr/local/lib/python2.7/dist-packages/suit/admin.py" in get_fieldsets
  97.                     fields.remove(self.sortable)

Exception Type: AttributeError at /admin/myapp/someobject/2/
Exception Value: 'tuple' object has no attribute 'remove'
```
