### PR TITLE
Fixed a bug where the `unicode` method was being invoked on field object...

### DIFF
--- a/suit/widgets.py
+++ b/suit/widgets.py
@@ -239,7 +239,10 @@ def wrap_as_input_group(s, append=''):
 def adjust_widget(field):
     widget = field.field.widget
     if isinstance(widget, ForeignKeyRawIdWidget):
-        field = unicode(field)
+        try:
+            field = unicode(field)
+        except NameError:
+            field = str(field)
         field = field.replace('RawIdAdminField', 'RawIdAdminField form-control')
         field = field.replace('<a', '<span class="input-group-btn"><a')
         field = field.replace('</a>', '<span class="glyphicon glyphicon-search"'
@@ -260,7 +263,10 @@ def adjust_widget(field):
         return mark_safe(field)
 
     elif isinstance(widget, RelatedFieldWidgetWrapper):
-        field = unicode(field)
+        try:
+            field = unicode(field)
+        except NameError:
+            field = str(field)
         # field = field.replace('RawIdAdminField', 'RawIdAdminField form-control')
         field = field.replace('<a', '<span class="input-group-btn"><a')
         field = field.replace('</a>', '<span class="glyphicon glyphicon-plus-sign color-success"'


### PR DESCRIPTION
Fixed a bug where the `unicode` method was being invoked on field objects. In Python 3.4, `unicode` is deprecated. Still compatible with Python 2.7.
