### PR TITLE
Attempt translation of menu apps and models in case user has marked them as translatable in settings

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse, resolve
+from django.utils.translation import ugettext as _
 
 try:
     from django.utils.six import string_types
@@ -158,6 +159,9 @@ class Menu(object):
 
         # Process absolute/named/model type urls
         app['url'] = self.process_url(app['url'], app)
+
+        # Attempt to translate app label with gettext
+        app['label'] = _(app['label'])
 
         return app
 
@@ -319,6 +323,9 @@ class Menu(object):
 
             # Detect if named url and convert it to absolute
             model['url'] = self.process_url(model['url'])
+
+            # Attempt to translate model label with gettext
+            model['label'] = _(model['label'])
 
             return model
 


### PR DESCRIPTION
We have custom django-suit menus in our project's settings and have just made everything translatable. The `_ = lambda s: s` trick in settings allows us to mark which strings should be translatable in the settings file and the `makemessages` command picked them up but django-suit wasn't using them. This branch fixes that and hopefully these are the correct places to be doing the `gettext()` lookup.