### PR TITLE
Added basic support for django-modeltranslation

### DIFF
--- a/suit/admin.py
+++ b/suit/admin.py
@@ -198,3 +198,44 @@ if 'cms' in settings.INSTALLED_APPS:
     except ImportError:
         pass
 
+if 'modeltranslation' in settings.INSTALLED_APPS:
+    try:
+        from modeltranslation.admin import TranslationAdmin
+        from modeltranslation.translator import translator
+
+        TranslationAdmin.suit_form_tabs = settings.LANGUAGES
+        TranslationAdmin.old_fieldsets = TranslationAdmin.get_fieldsets
+
+        def new_get_fieldsets(self, *args, **kwargs):
+            fieldsets = TranslationAdmin.old_fieldsets(self, *args, **kwargs)
+
+            translated_fields = self.trans_opts.get_field_names()
+
+            languages = [code for code, _ in settings.LANGUAGES]
+
+            def is_translated_field(field_name):
+                return field_name[-3] == '_' \
+                    and field_name[-2:] in languages \
+                    and field_name[:-3] in translated_fields
+
+            trans_fieldsets = dict(
+                (code, (language, [])) for code, language in settings.LANGUAGES
+            )
+            for name, fieldset in fieldsets:
+                for field_name in fieldset['fields'][:]:
+                    if is_translated_field(field_name):
+                        fieldset['fields'].remove(field_name)
+                        code = field_name[-2:]
+                        trans_fieldsets[code][1].append(field_name)
+
+            return fieldsets + [
+                (language, {
+                    'classes': ('suit-tab suit-tab-%s' % code, ),
+                    'fields': fields
+                }) for code, (language, fields) in trans_fieldsets.items()
+            ]
+
+        TranslationAdmin.get_fieldsets = new_get_fieldsets
+    except Exception as e:
+        print e
+        pass

--- a/suit/admin.py
+++ b/suit/admin.py
@@ -208,6 +208,7 @@ if 'modeltranslation' in settings.INSTALLED_APPS:
         def new_get_fieldsets(self, *args, **kwargs):
             fieldsets = TranslationAdmin.old_fieldsets(self, *args, **kwargs)
 
+            fieldsets = copy.deepcopy(fieldsets)
             translated_fields = self.trans_opts.get_field_names()
 
             languages = [code for code, _ in settings.LANGUAGES]

--- a/suit/admin.py
+++ b/suit/admin.py
@@ -201,7 +201,6 @@ if 'cms' in settings.INSTALLED_APPS:
 if 'modeltranslation' in settings.INSTALLED_APPS:
     try:
         from modeltranslation.admin import TranslationAdmin
-        from modeltranslation.translator import translator
 
         TranslationAdmin.suit_form_tabs = settings.LANGUAGES
         TranslationAdmin.old_fieldsets = TranslationAdmin.get_fieldsets
@@ -237,5 +236,4 @@ if 'modeltranslation' in settings.INSTALLED_APPS:
 
         TranslationAdmin.get_fieldsets = new_get_fieldsets
     except Exception as e:
-        print e
         pass


### PR DESCRIPTION
This is a fast addon to add support of django-modeltranslation to django-suit using suit-tabs.

Typically all models using the TranslationAdmin class will be patched to split the different translations among tabs.

Non translated fields will be repeated on each tab.

This is a basic version for now, but it meets my needs.