### PR TITLE
Base template fix

### DIFF
--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -72,7 +72,7 @@
                   {% url 'django-admindocs-docroot' as docsroot %}
                   {% if docsroot %}
                     <a href="{{ docsroot }}">{% trans 'Documentation' %}</a>
-                   <span class="separator">|</span>
+                    <span class="separator">|</span>
                   {% endif %}
                   <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a>
                   <span class="separator">|</span>

--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -77,8 +77,8 @@
                   <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a>
                   <span class="separator">|</span>
                   <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
-                  </span>
                 {% endblock %}
+                </span>
               </div>
             {% endif %}
             {% block nav-global %}{% endblock %}


### PR DESCRIPTION
Hi Kaspars,

Thanks so much for your work on Django Suit.

I've spotted a tiny bug in the `base.html` admin template where the `{% block %}` / `{% endblock %}` and `<span>` / `</span>` elements don't quite nest correctly - they're currently as follows:

    <span class="user-links">
    {% block userlinks %}
        <!-- ... -->
      </span>
    {% endblock %}

This makes it slightly trickier to override the block as it's harder to avoid creating invalid HTML. First commit fixes; second makes a tiny indentation tweak.

This isn't relevant to your `bs3` branch which refactors this area of the template, but should apply cleanly to `develop`.