### PR TITLE
Support custom admin menu items without overriding automatic generation.

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -93,6 +93,7 @@ class Menu(object):
         self.conf_icons = get_config('menu_icons')
         self.conf_menu_order = get_config('menu_order')
         self.conf_menu = get_config('menu')
+        self.conf_menu_extra = get_config('menu_extra')
 
     def get_app_list(self):
         menu = None
@@ -102,6 +103,9 @@ class Menu(object):
             menu = self.make_menu_from_old_format(self.conf_menu_order)
         else:
             menu = self.make_menu_from_native_only()
+
+        if self.conf_menu_extra:
+            menu += self.make_menu(self.conf_menu_extra)
 
         # Add icons and match active
         if menu:


### PR DESCRIPTION
Hi there,

Is there somewhere I can also update the docs? Test suite seems to not be converted over yet, so I didn't add any new test. Do you need copyright assignment? I don't care about these changes, only need to avoid maintaining a custom fork :)

----

This allows the developer to extend the bs3 main menu without affecting
the automatic menu item generation. Example usage:

````
from django.core.urlresolvers import reverse_lazy
from suit.apps import DjangoSuitConfig

    class MyDjangoSuitConfig(DjangoSuitConfig):
        menu_extra = [
            {
                'label': 'Facebook Stream',
                'icon': 'icon-facebook',
                'url': reverse_lazy('admin:facebook_stream')
            }
        ]
````