### PR TITLE
Fix readonly fields ignoring newlines in fieldset template

### DIFF
--- a/suit/templates/admin/includes/fieldset.html
+++ b/suit/templates/admin/includes/fieldset.html
@@ -41,7 +41,7 @@
           {% endif %}
 
         {% if field.is_readonly %}
-            <span class="readonly">{{ field|field_contents_foreign_linked }}</span>
+            <span class="readonly">{{ field|field_contents_foreign_linked|linebreaksbr }}</span>
         {% else %}
             {{ field.field }}
         {% endif %}


### PR DESCRIPTION
Applying the same fix as in this bug: https://code.djangoproject.com/ticket/19226