### PR TITLE
Fix warning Django 1.9

### DIFF
--- a/suit/templates/admin/app_index.html
+++ b/suit/templates/admin/app_index.html
@@ -1,6 +1,5 @@
 {% extends "admin/index.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% if not is_popup %}
     {% block breadcrumbs %}

--- a/suit/templates/admin/auth/user/change_password.html
+++ b/suit/templates/admin/auth/user/change_password.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_modify admin_urls %}
-{% load url from future %}
 
 {% block extrahead %}{{ block.super }}
   {% url 'admin:jsi18n' as jsi18nurl %}

--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static %}{% load suit_tags %}{% load url from future %}<!DOCTYPE html>
+{% load admin_static %}{% load suit_tags %}<!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/suit/templates/admin/change_form.html
+++ b/suit/templates/admin/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_modify suit_tags admin_urls %}
-{% load url from future %}
 
 {% block extrahead %}{{ block.super }}
   {% url 'admin:jsi18n' as jsi18nurl %}

--- a/suit/templates/admin/change_list.html
+++ b/suit/templates/admin/change_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_list admin_urls suit_list suit_tags %}
-{% load url from future %}
 
 {% block extrastyle %}
   {{ block.super }}

--- a/suit/templates/admin/cms/page/change_form.html
+++ b/suit/templates/admin/cms/page/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify cms_tags cms_admin %}
-{% load url from future %}
 {% block title %}{% trans "Change a page" %}{% endblock %}
 
 {% block extrahead %}

--- a/suit/templates/admin/cms/page/plugin_change_form.html
+++ b/suit/templates/admin/cms/page/plugin_change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify cms_admin %}
-{% load url from future %}
 {% block extrahead %}{{ block.super }}
 
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}suit/css/djangocms.css">

--- a/suit/templates/admin/delete_confirmation.html
+++ b/suit/templates/admin/delete_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls %}
-{% load url from future %}
 
 {% block breadcrumbs %}
   <ul class="breadcrumb">

--- a/suit/templates/admin/delete_selected_confirmation.html
+++ b/suit/templates/admin/delete_selected_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n l10n admin_urls %}
-{% load url from future %}
 
 {% block breadcrumbs %}
   <ul class="breadcrumb">

--- a/suit/templates/admin/filer/breadcrumbs.html
+++ b/suit/templates/admin/filer/breadcrumbs.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 <ul class="breadcrumb">
     <li>
         <a href="{% url 'admin:index' %}" title="{% trans "Go back to admin homepage" %}">{% trans "Home" %}</a>

--- a/suit/templates/admin/filer/delete_confirmation.html
+++ b/suit/templates/admin/filer/delete_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/filer/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 {% include "admin/filer/breadcrumbs.html" with instance=object breadcrumbs_action="Delete" %}

--- a/suit/templates/admin/filer/folder/change_form.html
+++ b/suit/templates/admin/filer/folder/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify filermedia %}
-{% load url from future %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/suit/templates/admin/filer/folder/directory_listing.html
+++ b/suit/templates/admin/filer/folder/directory_listing.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load filer_admin_tags filermedia i18n %}
-{% load url from future %}
-
 {% block extrahead %}{{ block.super }}
 {# upload stuff #}
 {{ media.js }}

--- a/suit/templates/admin/filer/folder/directory_table.html
+++ b/suit/templates/admin/filer/folder/directory_table.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load admin_list filermedia filer_tags %}
-{% load url from future %}
 
 <div id="toolbartable" class="results">
       <table id="result_list" class="table table-striped table-bordered table-hover table-condensed">

--- a/suit/templates/admin/filer/tools/clipboard/clipboard.html
+++ b/suit/templates/admin/filer/tools/clipboard/clipboard.html
@@ -1,5 +1,4 @@
 {% load thumbnail i18n %}
-{% load url from future %}
 
 <h4 class="italic-title clipboard-header{{ folder.is_root|yesno:' clipboard-root,' }}">{% trans "Clipboard" %}</h4>
 {% for clipboard in user.filer_clipboards.all %}

--- a/suit/templates/admin/import_export/base.html
+++ b/suit/templates/admin/import_export/base.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_modify %}
 {% load admin_urls %}
-{% load url from future %}
 
 {% block bodyclass %}{{ opts.app_label }}-{{ opts.object_name.lower }} change-form{% endblock %}
 {% if not is_popup %}

--- a/suit/templates/admin/import_export/export.html
+++ b/suit/templates/admin/import_export/export.html
@@ -1,5 +1,4 @@
 {% extends "admin/import_export/base.html" %}
-{% load url from future %}
 {% load i18n admin_urls import_export_tags %}
 
 {% block breadcrumbs_last %}{% trans "Export" %}{% endblock %}

--- a/suit/templates/admin/import_export/import.html
+++ b/suit/templates/admin/import_export/import.html
@@ -1,5 +1,4 @@
 {% extends "admin/import_export/base.html" %}
-{% load url from future %}
 {% load i18n admin_urls import_export_tags %}
 
 {% block breadcrumbs_last %}

--- a/suit/templates/admin/login.html
+++ b/suit/templates/admin/login.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static suit_tags %}
-{% load url from future %}
 
 {% block extrastyle %}{{ block.super }}
     {#    <link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />#}

--- a/suit/templates/admin/object_history.html
+++ b/suit/templates/admin/object_history.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumb">

--- a/suit/templates/registration/logged_out.html
+++ b/suit/templates/registration/logged_out.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs"><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></div>{% endblock %}

--- a/suit/templates/registration/password_change_form.html
+++ b/suit/templates/registration/password_change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
-{% load url from future %}
 
 {% block extrastyle %}{{ block.super }}
   {#    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}"/>#}

--- a/suit/templates/reversion/recover_form.html
+++ b/suit/templates/reversion/recover_form.html
@@ -1,5 +1,4 @@
 {% extends "reversion/revision_form.html" %}
-{% load url from future %}
 {% load i18n %}
 
 

--- a/suit/templates/reversion/recover_list.html
+++ b/suit/templates/reversion/recover_list.html
@@ -1,5 +1,4 @@
 {% extends "admin/base_site.html" %}
-{% load url from future %}
 {% load i18n %}
 
 

--- a/suit/templates/reversion/revision_form.html
+++ b/suit/templates/reversion/revision_form.html
@@ -1,5 +1,4 @@
 {% extends "admin/change_form.html" %}
-{% load url from future %}
 {% load i18n %}
 
 

--- a/suit/templates/suit/error_base.html
+++ b/suit/templates/suit/error_base.html
@@ -1,4 +1,4 @@
-{% load admin_static i18n %}{% load url from future %}<!DOCTYPE html>
+{% load admin_static i18n %}<!DOCTYPE html>
 <!--[if lt IE 9 ]><html lang="en"> <![endif]-->
 <!--[if (gte IE 9)|!(IE)]><!-->
 <html lang="en" xmlns="http://www.w3.org/1999/html"> <!--<![endif]-->

--- a/suit/templates/suit/menu.html
+++ b/suit/templates/suit/menu.html
@@ -1,6 +1,5 @@
 {#{% load sitetree %}#}
 {% load i18n suit_menu %}
-{% load url from future %}
 
 <div class="left-nav" id="left-nav">
   <ul>


### PR DESCRIPTION
Fix this:
```
/home/tulipan/Proyectos/TiempoTurco/lib/python3.4/site-packages/django/templatetags/future.py:25: RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
  RemovedInDjango19Warning)
```