### PR TITLE
Fixing Django 1.8 compatibility

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse, resolve
+from django.core.urlresolvers import NoReverseMatch
 
 try:
     from django.utils.six import string_types
@@ -25,7 +26,12 @@ def get_menu(context, request):
         return None
 
     # Try to get app list
-    template_response = get_admin_site(context.current_app).index(request)
+    try:
+        template_response = get_admin_site(context.current_app).index(request)
+    except NoReverseMatch:
+        # Django 1.8 uses request.current_app instead of context.current_app
+        template_response = get_admin_site(request.current_app).index(request)
+
     try:
         app_list = template_response.context_data['app_list']
     except Exception:


### PR DESCRIPTION
See here: https://docs.djangoproject.com/en/1.8/releases/1.8/#current-app-argument-of-template-related-apis

I was getting errors while running with a custom AdminSite, but I guess the case would be the same with the built-in AdminSite class.