### PR TITLE
Bs3 Mark correct day as "active"

### DIFF
--- a/suit/static/suit/js/datepicker/bootstrap-datepicker.js
+++ b/suit/static/suit/js/datepicker/bootstrap-datepicker.js
@@ -48,7 +48,7 @@
 				var val = d && d.valueOf();
 				ignoreTime = typeof(ignoreTime) === 'undefined';
 				if (ignoreTime) {
-					val = d.getFullYear().toString() + d.getMonth() + d.getDate();
+					val = d.getFullYear().toString() + d.getMonth() + d.getUTCDate();
 				}
 				for (var i=0, l=this.length; i < l; i++)
 					if (ignoreTime) {

--- a/suit/static/suit/js/datepicker/bootstrap-datepicker.js
+++ b/suit/static/suit/js/datepicker/bootstrap-datepicker.js
@@ -48,7 +48,7 @@
 				var val = d && d.valueOf();
 				ignoreTime = typeof(ignoreTime) === 'undefined';
 				if (ignoreTime) {
-					val = d.getFullYear().toString() + d.getMonth() + d.getUTCDate();
+					val = d.getUTCFullYear().toString() + d.getUTCMonth() + d.getUTCDate();
 				}
 				for (var i=0, l=this.length; i < l; i++)
 					if (ignoreTime) {


### PR DESCRIPTION
I had a problem with the date picker always marking selected day +1 as `active` (using Pacific timezone). I realized the date picker JS code compares local dates to UTC dates to find the `active` date. This patch resolved the issue.

tl;dr datepicker marks one day after selected day as active