### PR TITLE
Some minor fixes

### DIFF
--- a/suit/templates/admin/change_list.html
+++ b/suit/templates/admin/change_list.html
@@ -60,16 +60,16 @@
 
         <div class="toolbar-content clearfix">
           {% block object-tools %}
-            {% if has_add_permission %}
-              <div class="object-tools">
-                {% block object-tools-items %}
+            <div class="object-tools">
+              {% block object-tools-items %}
+                {% if has_add_permission %}
                   <a href="{% url cl.opts|admin_urlname:'add' %}{% if is_popup %}?_popup=1{% endif %}" class="btn btn-success">
                     <i class="icon-plus-sign icon-white"></i>&nbsp;
                     {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
                   </a>
-                {% endblock %}
-              </div>
-            {% endif %}
+                {% endif %}
+              {% endblock %}
+            </div>
           {% endblock %}
 
           {% block search %}{% search_form cl %}{% endblock %}

--- a/suit/templates/admin/cms/page/change_list.html
+++ b/suit/templates/admin/cms/page/change_list.html
@@ -133,16 +133,16 @@
 
   <div class="toolbar-content clearfix">
     {% block object-tools %}
-      {% if has_add_permission %}
-        <div class="object-tools">
-          {% block object-tools-items %}
+      <div class="object-tools">
+        {% block object-tools-items %}
+          {% if has_add_permission %}
             <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="btn btn-success">
               <i class="icon-plus-sign icon-white"></i>&nbsp;
               {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
             </a>
-          {% endblock %}
-        </div>
-      {% endif %}
+          {% endif %}
+        {% endblock %}
+      </div>
     {% endblock %}
 
     {% block search %}{% search_form cl %}{% endblock %}

--- a/suit/templates/admin/search_form.html
+++ b/suit/templates/admin/search_form.html
@@ -36,6 +36,11 @@
         <input type="hidden" name="{{ POPUP_VAR }}" value="1">
       {% endif %}
 
+      {% admin_extra_filters cl as extra_filters %}
+      {% for pair in extra_filters.items %}
+            {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
+      {% endfor %}
+
     </form>
   </div>
 {% endif %}

--- a/suit/templatetags/suit_tags.py
+++ b/suit/templatetags/suit_tags.py
@@ -1,3 +1,4 @@
+import itertools
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import NoReverseMatch, reverse
@@ -80,3 +81,12 @@ def suit_bc(*args):
 @register.assignment_tag
 def suit_bc_value(*args):
     return utils.value_by_version(args)
+
+
+@register.assignment_tag
+def admin_extra_filters(cl):
+    """ Return the dict of used filters which is not included
+    in list_filters form """
+    used_parameters = list(itertools.chain(*(s.used_parameters.keys()
+                                             for s in cl.filter_specs)))
+    return {k: v for k, v in cl.params.items() if k not in used_parameters}


### PR DESCRIPTION
Hello!
First of all thanks for a perfect admin interface! 
I had some problems when trying to use it in my project. They are described below.
1. The hole object-tools block shows only if user has add permission. That is not correct and add_permission should affect only an add button visibility.
2. In original django admin changelist you can add some filters direct to query string. Like this: http://djangosuit.com/admin/examples/country/?independence_day__gte=1990-01-01
I think, it's a useful dark feature. It's work in django-suit too, but those filters aren't added to changelist search form. So they are missed when you try to use this form.

The changes contain fix for this cases. Please review these.

Thanks in advance!