### PR TITLE
fix for add tag when second variable is not passed

### DIFF
--- a/suit/templates/admin/login.html
+++ b/suit/templates/admin/login.html
@@ -29,11 +29,19 @@
         {% endif %}
 
         {% if form.non_field_errors or form.this_is_the_login_form.errors %}
-            {% for error in form.non_field_errors|add:form.this_is_the_login_form.errors %}
-                <p class="errornote alert alert-error">
-                    {{ error }}
-                </p>
-            {% endfor %}
+            {% if form.this_is_the_login_form.errors %}
+                {% for error in form.non_field_errors|add:form.this_is_the_login_form.errors %}
+                    <p class="errornote alert alert-error">
+                        {{ error }}
+                    </p>
+                {% endfor %}
+            {% else %}
+                {% for error in form.non_field_errors %}
+                    <p class="errornote alert alert-error">
+                        {{ error }}
+                    </p>
+                {% endfor %}
+            {% endif %}
         {% endif %}
 
         <div id="content-main">


### PR DESCRIPTION
This fixes the problem of the form.non_field_errors not being shown, as now when I enter the wrong password nothings happens - no error messages are shown. It's probably caused by the fact that form.this_is_the_login_form.errors is not being passed and the add: with None causes the for to loose form.non_field_errors