### PR TITLE
Fixes suit-form-confirm failing on unload

### DIFF
--- a/suit/static/suit/js/suit-form-confirm.js
+++ b/suit/static/suit/js/suit-form-confirm.js
@@ -23,6 +23,7 @@ var confirmExitIfModified = (function () {
             else if (type == "hidden" || type == "password" ||
                 type == "text" || type == "textarea") {
                 var cls = element.getAttribute('class');
+                if (!cls) cls = '';
                 if (element.value != element.defaultValue &&
                     // Fix for select2 multiple
                     cls.indexOf('select2') == -1 &&


### PR DESCRIPTION
If input has no class attribute defined it will fail during unload.
This would prevent the correct message from being displayed.

PD: cls value is null when getAttribute doesn't find anything so indexOf fails