### PR TITLE
replace template import

### DIFF
--- a/suit/templatetags/suit_compat.py
+++ b/suit/templatetags/suit_compat.py
@@ -1,7 +1,7 @@
-from django.template.base import Library
+from django import template
 from ..compat import url as url_compat
 
-register = Library()
+register = template.Library()
 
 
 @register.tag


### PR DESCRIPTION
`from django.template.base import Library` raise `ImportError` in Django1.9
