### PR TITLE
Adding django-suit-rq to related packages.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,5 +38,6 @@ Related packages
 Related packages you can contribute to:
 
 * `django-suit-redactor <https://github.com/darklow/django-suit-redactor>`_ - Imperavi Redactor (WYSIWYG editor) integration app
-* `django-suit-ckeditor <https://github.com/darklow/django-suit-ckeditor>`_ - CKEditor (WYSIWYG editor) integration app:
+* `django-suit-ckeditor <https://github.com/darklow/django-suit-ckeditor>`_ - CKEditor (WYSIWYG editor) integration app
+* `django-suit-rq <https://github.com/gsmke/django-suit-rq>`_ - Django-RQ (Queuing library) integration app
 * `django-suit-examples <https://github.com/darklow/django-suit-examples>`_ - demo app


### PR DESCRIPTION
We created some suit templates for Django-RQ. Not sure if this is an appropriate place for this or not. Also removed a semi-colon after "CKEditor (WYSIWYG editor) integration app" that looked like a typo.