### PR TITLE
Replace hard-coded admin delete URLs with url tags for Django >= 1.9

### DIFF
--- a/suit/templates/admin/page_submit_line.html
+++ b/suit/templates/admin/page_submit_line.html
@@ -1,17 +1,27 @@
-{% load i18n %}
+{% load i18n admin_urls suit_tags %}
+{% suit_django_version as django_version %}
 <div class="submit-row clearfix">
   {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
   {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>{% endif %}
   {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>{%endif%}
   {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>{% endif %}
 
-  {% if show_delete_link %}<a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
+  {% if show_delete_link %}
+    {% if django_version < 1.9 %}
+      <a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
+    {% else %}
+      <a href="{% url opts|admin_urlname:'delete' original.pk|admin_urlquote %}" class="text-error deletelink">{% trans "Delete" %}</a>
+    {% endif %}
   {% endif %}
   {% if show_delete_translation %}
     {% if show_delete_link %}
     <br>
     {% endif %}
-    <a href="delete-translation/?language={{ language }}" class="text-error deletelink delete-translation">{% blocktrans with language_name|lower as language %}Delete {{ language }} translation{% endblocktrans %}</a>
+    {% if django_version < 1.9 %}
+      <a href="delete-translation/?language={{ language }}" class="text-error deletelink delete-translation">{% blocktrans with language_name|lower as language %}Delete {{ language }} translation{% endblocktrans %}</a>
+    {% else %}
+      <a href="{% url opts|admin_urlname:'delete' original.pk|admin_urlquote %}-translation/?language={{ language }}" class="text-error deletelink delete-translation">{% blocktrans with language_name|lower as language %}Delete {{ language }} translation{% endblocktrans %}</a>
+    {% endif %}
   {% endif %}
 
 </div>

--- a/suit/templates/admin/submit_line.html
+++ b/suit/templates/admin/submit_line.html
@@ -1,10 +1,16 @@
-{% load i18n %}
+{% load i18n admin_urls suit_tags %}
+{% suit_django_version as django_version %}
 <div class="submit-row clearfix">
   {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save">{% trans 'Save' %}</button>{% endif %}
   {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high">{% trans 'Save and continue editing' %}</button>{% endif %}
   {% if show_save_as_new %}<button type="submit" name="_saveasnew" class="btn">{% trans 'Save as new' %}</button>{%endif%}
   {% if show_save_and_add_another %}<button type="submit" name="_addanother" class="btn">{% trans 'Save and add another' %}</button>{% endif %}
 
-  {% if show_delete_link %}<a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
+  {% if show_delete_link %}
+    {% if django_version < 1.9 %}
+      <a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
+    {% else %}
+      <a href="{% url opts|admin_urlname:'delete' original.pk|admin_urlquote %}" class="text-error deletelink">{% trans "Delete" %}</a>
+    {% endif %}
   {% endif %}
 </div>


### PR DESCRIPTION
If the Django version is less than 1.9, use the existing hard-coded URL.
If it's equal to or greater than 1.9, use the URL reverse tag.
Fixes #466