### PR TITLE
Bugfix sortable when setting order value

### DIFF
--- a/suit/static/suit/js/sortables.js
+++ b/suit/static/suit/js/sortables.js
@@ -133,7 +133,7 @@
                 var i = 0, value;
                 $(selector).each(function () {
                     var $input = $(this);
-                    var fieldset_id = $input.attr('name').split(/-\d+-/)[0];
+                    var fieldset_id = $input.attr('name').split(/-(\d+)-/)[1];
                     // Check if any of new dynamic block values has been added
                     var $set_block = $input.closest('.dynamic-' + fieldset_id);
                     var $changed_fields = $set_block.find(":input[value!=''][type!='hidden']").filter(filter_unchanged);


### PR DESCRIPTION
Basically what was happening was that when submitting the sortable inlines the order value wasn't being set correctly.

A split was being made, like this:
`var fieldset_id = $input.attr('name').split(/-\d+-/)[0];`

But this regex was just removing the digit form the returned array, which is the value necessary to set the respective order value.

So I did a little research on split and I got this:

> If separator contains capturing parentheses, matched results are returned in the array.

So, to get the digit in the returned array what I did was this:
`var fieldset_id = $input.attr('name').split(/-(\d+)-/)[1];`

[mozilla developer - split reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)

That solved the issue.