### PR TITLE
Django 1.9 support

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse, resolve
-from django.core.urlresolvers import NoReverseMatch
 
 try:
     from django.utils.six import string_types
@@ -28,11 +27,11 @@ def get_menu(context, request):
         return None
 
     # Try to get app list
-    try:
-        template_response = get_admin_site(context.current_app).index(request)
-    except NoReverseMatch:
+    if hasattr(request, 'current_app'):
         # Django 1.8 uses request.current_app instead of context.current_app
         template_response = get_admin_site(request.current_app).index(request)
+    else:
+        template_response = get_admin_site(context.current_app).index(request)
 
     try:
         app_list = template_response.context_data['app_list']

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -49,6 +49,10 @@ def get_admin_site(current_app):
     """
     try:
         resolver_match = resolve(reverse('%s:index' % current_app))
+        # Django 1.9 exposes AdminSite instance directly on view function
+        if hasattr(resolver_match.func, 'admin_site'):
+            return resolver_match.func.admin_site
+
         for func_closure in resolver_match.func.func_closure:
             if isinstance(func_closure.cell_contents, AdminSite):
                 return func_closure.cell_contents


### PR DESCRIPTION
Fixes proper `current_app` lookup in Django 1.8 and 1.9 through `request.current_app`. The previous implementation of this was broken.

Also improves the lookup of the AdminSite instance through `func.admin_site` which is exposed in Django 1.9. Django 1.8 and earlier is still supported through the old lookup implementation.