### PR TITLE
Use '__closure__' over deprecated 'func_closure'

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -53,7 +53,7 @@ def get_admin_site(current_app):
         if hasattr(resolver_match.func, 'admin_site'):
             return resolver_match.func.admin_site
 
-        for func_closure in resolver_match.func.func_closure:
+        for func_closure in resolver_match.func.__closure__:
             if isinstance(func_closure.cell_contents, AdminSite):
                 return func_closure.cell_contents
     except:


### PR DESCRIPTION
This is just a rebased version of @fdanielsen PR https://github.com/darklow/django-suit/pull/476

The `func_closure` property of functions to access their closure context
has been renamed to `__closure__` in Python 3, with backports to Python
2 starting with 2.6. This updates the menu template tag to inspect index
view functions through `__closure__` instead for Python 3 compatibility,
foregoing Python 2.5 and earlier support.