### PR TITLE
Fix extra classes inserted in TabularInline when there was an error

### DIFF
--- a/suit/templates/admin/edit_inline/tabular.html
+++ b/suit/templates/admin/edit_inline/tabular.html
@@ -30,7 +30,7 @@
         {% for fieldset in inline_admin_form %}
           {% for line in fieldset %}
             {% for field in line %}
-              <td{% if field.field.name %} class="field-{{ field.field.name }}{{ field.field.errors|yesno:' control-group error,' }}{{ field.field.errors|yesno:' control-group error,' }}"{% endif %}>
+              <td{% if field.field.name %} class="field-{{ field.field.name }}{{ field.field.errors|yesno:' control-group error,' }}"{% endif %}>
 
               {% if forloop.parentloop.first %}
                 {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}


### PR DESCRIPTION
When there is a form error, there are duplicated class names in the HTML output.