### PR TITLE
add top and bottom links for sortable inlines

### DIFF
--- a/suit/static/suit/js/sortables.js
+++ b/suit/static/suit/js/sortables.js
@@ -50,10 +50,21 @@
                     if ($next.is(':visible') && $next.length) {
                         $row.insertAfter($next).addClass('selected')
                     }
-                } else {
+                } else if ($arrow.data('dir') === 'up') {
                     $prev = $row.prev();
                     if ($prev.is(':visible') && $prev.length) {
                         $row.insertBefore($prev).addClass('selected')
+                    }
+                } else if ($arrow.data('dir') === 'top') {
+                    $prev = $($row.parents('tbody').children()[0]);
+                    if ($prev.is(':visible') && $prev.length) {
+                        $row.insertBefore($prev).addClass('selected')
+                    }
+                } else if ($arrow.data('dir') === 'bottom') {
+                    var children = $row.parents('tbody').children();
+                    $prev = $(children[children.length - 2]);
+                    if ($prev.is(':visible') && $prev.length) {
+                        $row.insertAfter($prev).addClass('selected')
                     }
                 }
             }
@@ -82,8 +93,10 @@
                 $sortable = $(this),
                 is_stacked = $sortable.hasClass('suit-sortable-stacked');
 
-            var $up_link = create_link(icon, 'up', on_arrow_click, is_stacked),
-                $down_link = create_link(icon.replace('-up', '-down'), 'down', on_arrow_click, is_stacked);
+            var $top_link = create_link(icon.replace('-arrow-up', '-chevron-up'), 'top', on_arrow_click, is_stacked),
+                $up_link = create_link(icon, 'up', on_arrow_click, is_stacked),
+                $down_link = create_link(icon.replace('-up', '-down'), 'down', on_arrow_click, is_stacked),
+                $bottom_link = create_link(icon.replace('-arrow-up', '-chevron-down'), 'bottom', on_arrow_click, is_stacked);
 
             if (is_stacked) {
                 var $sortable_row = $sortable.closest('div.form-row'),
@@ -97,8 +110,10 @@
                 $sortable_row.remove();
             } else {
                 $sortable.parent().append($inline_sortable);
+                $inline_sortable.append($top_link);
                 $inline_sortable.append($up_link);
                 $inline_sortable.append($down_link);
+                $inline_sortable.append($bottom_link);
             }
 
         });


### PR DESCRIPTION
If you deal with a lot of inlines, moving an item to the top or bottom can involve a lot of cumbersome clicks. I extended the sortable controls with two new buttons: one to put an inline straight to the top or to the button.

This works now for our use case, but is not finished in a general way. I do not have the knowledge of the project and also not test cases to see if it works in all cases. I don't know how it works for trees or stacked inlines.

I wanted to share the code anyway, maybe you feel like adapting and finishing it.

<img width="155" alt="bildschirmfoto 2016-07-15 um 17 55 51" src="https://cloud.githubusercontent.com/assets/2032443/16880409/6ec769fa-4ab5-11e6-88e9-b93c73645d51.png">
