### PR TITLE
Add compatibility for Django 1.10

### DIFF
--- a/suit/templatetags/suit_tags.py
+++ b/suit/templatetags/suit_tags.py
@@ -100,13 +100,13 @@ def suit_django_version():
     return django_version
 
 
-if django_version < 1.9:
+if django_version < (1, 9):
     # Add empty tags to avoid Django template errors if < Django 1.9
     @register.simple_tag
     def add_preserved_filters(*args, **kwargs):
         pass
 
-if django_version < 1.5:
+if django_version < (1, 5):
     # Add admin_urlquote filter to support Django 1.4
     from django.contrib.admin.util import quote
     @register.filter

--- a/suit/tests/utils.py
+++ b/suit/tests/utils.py
@@ -4,9 +4,6 @@ from django.test import TestCase
 
 
 class UtilsTestCase(TestCase):
-    def test_django_major_version(self):
-        self.assertEqual(utils.django_major_version(), float(get_version()[:3]))
-
     def get_args(self):
         return [1.4, 'x', 1.5, 'y', 's', 'z']
 

--- a/suit/utils.py
+++ b/suit/utils.py
@@ -2,7 +2,7 @@ from django import VERSION
 
 
 def django_major_version():
-    return float('.'.join([str(i) for i in VERSION][:2]))
+    return VERSION[:2]
 
 
 def value_by_version(args):
@@ -11,7 +11,8 @@ def value_by_version(args):
     Return latest value if version not found
     """
     version_map = args_to_dict(args)
-    return version_map.get(django_major_version(),
+    major_version = '.'.join(str(v) for v in django_major_version())
+    return version_map.get(major_version,
                            list(version_map.values())[-1])
 
 


### PR DESCRIPTION
The Django major version number was converted to a float so v1.10
became 1.1 which was of course considered < 1.5 or 1.9, so some
compatibility checks were incorrect.

Fixes #524

It might be worth updating Travis to include Django 1.9 and 1.10 for future builds too.