### PR TITLE
Fixed context.current_app in Django 1.10

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -31,7 +31,10 @@ def get_menu(context, request):
         # Django 1.8 uses request.current_app instead of context.current_app
         template_response = get_admin_site(request.current_app).index(request)
     else:
-        template_response = get_admin_site(context.current_app).index(request)
+        try:
+            template_response = get_admin_site(context.current_app).index(request)
+        except AttributeError:
+            template_response = get_admin_site(context.request.resolver_match.namespace).index(request)
 
     try:
         app_list = template_response.context_data['app_list']

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -33,6 +33,8 @@ def get_menu(context, request):
     else:
         try:
             template_response = get_admin_site(context.current_app).index(request)
+        # Django 1.10 removed the current_app parameter for some classes and functions. 
+        # Check the release notes.
         except AttributeError:
             template_response = get_admin_site(context.request.resolver_match.namespace).index(request)
 


### PR DESCRIPTION
Fixed AttributeError: 'RequestContext' object has no attribute 'current_app'.
See [Django 1.10 release notes](https://docs.djangoproject.com/en/1.10/releases/1.10/)