### PR TITLE
Fixed #531: validating actions on change form save

### DIFF
--- a/suit/templates/admin/change_form.html
+++ b/suit/templates/admin/change_form.html
@@ -83,7 +83,7 @@
   <div id="content-main" class="inner-two-columns">
 
     <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post"
-          id="{% firstof opts.model_name opts.module_name %}_form" class="form-horizontal">
+          id="{% firstof opts.model_name opts.module_name %}_form" class="form-horizontal" novalidate>
 
       <div class="inner-right-column">
 

--- a/suit/templates/admin/change_list.html
+++ b/suit/templates/admin/change_list.html
@@ -90,7 +90,7 @@
 
         <form id="changelist-form" action="" method="post"
             {% if cl.formset.is_multipart %}
-              enctype="multipart/form-data"{% endif %} class="form-inline">{% csrf_token %}
+              enctype="multipart/form-data"{% endif %} class="form-inline" novalidate>{% csrf_token %}
           {% if cl.formset %}
             <div>{{ cl.formset.management_form }}</div>
           {% endif %}


### PR DESCRIPTION
Added novalidate to <form> tags both on change_list.html and
change_form.html to be more compatible with django 1.10 release which
added 'required' field to all required form fields by default. This fix
is exactly how django handles that problem in default admin style.