### PR TITLE
{% load cycle from future %} and {% load firstof from future %}

### DIFF
--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static suit_tags %}{% load firstof from future %}<!DOCTYPE html>
+{% load admin_static suit_tags %}<!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
   <meta charset="utf-8">

--- a/suit/templates/admin/base_site.html
+++ b/suit/templates/admin/base_site.html
@@ -1,6 +1,5 @@
 {% extends "admin/base.html" %}
 {% load suit_tags %}
-{% load firstof from future %}
 
 {% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 

--- a/suit/templates/admin/change_list_results.html
+++ b/suit/templates/admin/change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static suit_list %}{% load cycle from future %}
+{% load i18n admin_static suit_list %}
 {% if result_hidden_fields %}
   <div class="hiddenfields">{# DIV for HTML validation #}
     {% for item in result_hidden_fields %}{{ item }}{% endfor %}

--- a/suit/templates/admin/edit_inline/tabular.html
+++ b/suit/templates/admin/edit_inline/tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_modify %}{% load cycle from future %}
+{% load i18n admin_static admin_modify %}
 {% load suit_forms %}
 <div class="inline-group {{ inline_admin_formset.opts.suit_classes }}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">


### PR DESCRIPTION
This syntax is now deprecated in Django 1.10

Tested in django  1.7 , 1.8 , 1.9 and 1.10