### PR TITLE
Fixed pagination info when showing all rows.

### DIFF
--- a/suit/templatetags/suit_list.py
+++ b/suit/templatetags/suit_list.py
@@ -52,7 +52,7 @@ def paginator_info(cl):
 
     # If we show all rows of list (without pagination)
     if cl.show_all and cl.can_show_all:
-        entries_from = 1
+        entries_from = 1 if paginator.count > 0 else 0
         entries_to = paginator.count
     else:
         entries_from = (

--- a/suit/templatetags/suit_list.py
+++ b/suit/templatetags/suit_list.py
@@ -49,11 +49,18 @@ def paginator_number(cl, i):
 @register.simple_tag
 def paginator_info(cl):
     paginator = cl.paginator
-    entries_from = (
-        (paginator.per_page * cl.page_num) + 1) if paginator.count > 0 else 0
-    entries_to = entries_from - 1 + paginator.per_page
-    if paginator.count < entries_to:
+
+    # If we show all rows of list (without pagination)
+    if cl.show_all and cl.can_show_all:
+        entries_from = 1
         entries_to = paginator.count
+    else:
+        entries_from = (
+            (paginator.per_page * cl.page_num) + 1) if paginator.count > 0 else 0
+        entries_to = entries_from - 1 + paginator.per_page
+        if paginator.count < entries_to:
+            entries_to = paginator.count
+
     return '%s - %s' % (entries_from, entries_to)
 
 


### PR DESCRIPTION
When showing all rows you can see at the bottom of `change_list`: `1 - 20 / 35 something`.

Now it correctly displays: `1 - 35 / 35 something`.
