### PR TITLE
Django filer incompatibility fixes

### DIFF
--- a/suit/menu.py
+++ b/suit/menu.py
@@ -44,7 +44,8 @@ class MenuManager(object):
         # Variable available_apps structure:
         # https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#adminsite-methods
         self.available_apps = available_apps
-
+        if available_apps is None:
+            self.available_apps = [] # For cases where an app doesn't initialize this
         self.context = context
         self.request = request
         self.current_app = get_current_app(request)

--- a/suit/sass/suit.scss
+++ b/suit/sass/suit.scss
@@ -27,3 +27,5 @@
 @import 'pages/dashboard';
 @import 'pages/changelist';
 @import 'pages/changeform';
+
+@import 'thirdparty/filer';

--- a/suit/sass/thirdparty/_filer.scss
+++ b/suit/sass/thirdparty/_filer.scss
@@ -1,0 +1,6 @@
+body.suit_layout_vertical.filebrowser #container #content{
+    margin-left:0 !important;
+}
+.suit_layout_horizontal.filebrowser .filter-files-container, .suit_layout_vertical.filebrowser .filter-files-container{
+    width:360px;
+}

--- a/suit/templates/admin/filer/folder/directory_listing.html
+++ b/suit/templates/admin/filer/folder/directory_listing.html
@@ -1,0 +1,4 @@
+{% extends "admin/filer/folder/directory_listing.html" %}
+{% load i18n staticfiles filer_admin_tags suit_tags %}
+
+{% block bodyclass %}{{ block.super|suit_body_class:request }} change-list filebrowser{% endblock %} {# CHANGED #}


### PR DESCRIPTION
Minor fixes to bring back smooth integration with django filer. Might not be complete (in terms of perfect integration) but if fixes issues that were making the integration impossible (500 error and major css issues).
With this, filer >= 1.2.6 works mostly as expected.