### PR TITLE
Fix empty Welcome username for custom user model

### DIFF
--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -68,7 +68,7 @@
                   {% trans 'Welcome,' %}
                   <strong>
                     {% filter force_escape %}
-                      {% firstof user.first_name user.username %}{% endfilter %}</strong>.
+                      {% firstof user.first_name user.get_username %}{% endfilter %}</strong>.
                 {% endblock %}
                 <span class="user-links">
                 {% block userlinks %}


### PR DESCRIPTION
A django custom user model does not always have a `username` attribute,
but the `get_username()` method is present for all user implementations.