### PR TITLE
add compatibility with Django 2.0

### DIFF
--- a/suit/admin.py
+++ b/suit/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.db import models
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 """
 Adapted by using following examples:
@@ -91,7 +91,7 @@ class RelatedFieldAdmin(admin.ModelAdmin):
                 field = model._meta.get_field(field_name)
             except models.FieldDoesNotExist:
                 continue
-            if isinstance(field.rel, models.ManyToOneRel):
+            if isinstance(field, models.ManyToManyField):
                 select_related.append(field_name)
 
         return qs.select_related(*select_related)

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -220,7 +220,7 @@ class MenuManager(object):
             return menu_item
         if '/' in menu_item.url:
             return menu_item
-        from django.core.urlresolvers import reverse, NoReverseMatch
+        from django.urls import reverse, NoReverseMatch
         try:
             menu_item.url = reverse(menu_item.url, current_app=self.current_app)
             menu_item._url_name = menu_item.url

--- a/suit/templatetags/suit_forms.py
+++ b/suit/templatetags/suit_forms.py
@@ -102,7 +102,7 @@ def suit_form_field_widget_class(field):
     return ''
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def suit_form_conf(context, param_name, inline_admin_formset=None):
     """
     Get form config param

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -2,13 +2,13 @@ import logging
 from django import template
 from django.contrib.admin import AdminSite
 from django.http import HttpRequest
-from django.core.urlresolvers import reverse, resolve
+from django.urls import reverse, resolve
 from suit.menu import MenuManager
 
 register = template.Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_menu(context, request):
     """
     :type request: WSGIRequest

--- a/suit/templatetags/suit_tags.py
+++ b/suit/templatetags/suit_tags.py
@@ -24,7 +24,7 @@ def suit_body_class(value, request):
     return ' '.join(css_classes)
 
 
-@register.assignment_tag
+@register.simple_tag
 def suit_conf_value(name, model_admin=None):
     if model_admin:
         value_by_ma = getattr(model_admin, 'suit_%s' % name.lower(), None)

--- a/suit/tests/test_routes.py
+++ b/suit/tests/test_routes.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 class RoutesTestCase(TestCase):


### PR DESCRIPTION
`django.core.urlresolvers` and `assignment_tag` are removed on Django 2.0