### PR TITLE
Support for custom view_on_site() in ModelAdmin

### DIFF
--- a/suit/templates/admin/change_form.html
+++ b/suit/templates/admin/change_form.html
@@ -109,7 +109,7 @@
                 </li>
                 {% if has_absolute_url %}
                   <li>
-                    <a href="{{ original.get_absolute_url }}" class="viewsitelink"><i class="icon-eye-open icon-alpha75"></i>{% trans "View on site" %}</a>
+                    <a href="{{ absolute_url }}" class="viewsitelink"><i class="icon-eye-open icon-alpha75"></i>{% trans "View on site" %}</a>
                   </li>
                 {% endif %}
 


### PR DESCRIPTION
Hi!

Django admin [allows](https://docs.djangoproject.com/en/2.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.view_on_site) to use callable `view_on_site()` within `ModelAdmin`.

This is useful when you want to customize admin URLs without changing get_absolute_url(). However, django-suit uses model `get_absolute_url()` attribute, bypassing this customisation.

This PR fixes it. It is safe to merge because the [peace of code](https://github.com/django/django/blame/ef2512b2ffdb719e5c0fb82142f9ce8478282823/django/contrib/admin/options.py#L1089) in django template context hasn't been changed for 4 years.