### PR TITLE
Change form.onsubmit to eventlistener

### DIFF
--- a/suit/static/suit/js/suit-form-confirm.js
+++ b/suit/static/suit/js/suit-form-confirm.js
@@ -49,10 +49,10 @@ var confirmExitIfModified = (function () {
     return function (form_id, message) {
         var form = document.forms[form_id]
         if (form) {
-            form.onsubmit = function (e) {
+            form.addEventListener('submit', function (e) {
                 e = e || window.event;
                 submit = true
-            };
+            });
         }
         window.onbeforeunload = function (e) {
             e = e || window.event;


### PR DESCRIPTION
In our usecase, we have another library that overloads form.onsubmit, and submits the form. However, the `formIsDirty` is also true ( because of the changes to Django Multiple Select Box ) and hence the confirmation pops up. 
In the proposed change, Django suit would work together nicely with other libraries.