### PR TITLE
Fix horizontal filter params.

### DIFF
--- a/suit/templatetags/suit_list.py
+++ b/suit/templatetags/suit_list.py
@@ -202,9 +202,11 @@ def suit_list_filter_horizontal(filters, cl):
 
 @register.filter
 def suit_list_filter_horizontal_params(params, cl):
-    filter_horizontal = getattr(cl.model_admin, 'suit_list_filter_horizontal', [])
-    # Add split for date__gte, field__isnull filters
-    return [p for p in params if p[0].split('__')[0] not in filter_horizontal]
+    # This collects params of vertical filters so they can be rendered as part of horizontal form
+    vertical_keys = set()
+    for vf in suit_list_filter_vertical(cl.filter_specs, cl):
+        vertical_keys |= set(vf.expected_parameters())
+    return [p for p in params if p[0] in vertical_keys]
 
 
 def get_filter_id(spec):


### PR DESCRIPTION
We can't just look at params alone since there are many edge cases
that don't work.
This is arguably the correct way to do this since it looks at expected_parameters and param name may have nothing to do with filter id or field name.