### PR TITLE
Fix #710 - Remove `admin_static` template tag in favor of `static`

### DIFF
--- a/demo/demo/templates/admin/base_site.html
+++ b/demo/demo/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_site.html' %}
-{% load suit_tags admin_static %}
+{% load suit_tags static %}
 
 {# Following is an example how to extend admin by custom CSS or JS files #}
 {# Add extra CSS for admin #}

--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base.html' %}
-{% load i18n admin_static suit_tags %}
+{% load i18n static suit_tags %}
 
 {% block stylesheet %}{% static "suit/css/suit.css" %}{% endblock %}
 

--- a/suit/templates/admin/change_list_results.html
+++ b/suit/templates/admin/change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static suit_list %}
+{% load i18n static suit_list %}
 {% if result_hidden_fields %}
 <div class="hiddenfields">{# DIV for HTML validation #}
 {% for item in result_hidden_fields %}{{ item }}{% endfor %}


### PR DESCRIPTION
Hi, 

this is my attempt to fix #710 

`admin_static` tag was deprecated since 2.1 and before was representing the same `static` tag.
So, I believe, we can safely replace it to remove deprecation warnings.