### PR TITLE
Django 2.2: Improve `get_native_model_url` model handling

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -353,7 +353,7 @@ class Menu(object):
         }
 
     def get_native_model_url(self, model):
-        return model.get('admin_url', model.get('add_url', ''))
+        return model.get('admin_url') or model.get('add_url', '')
 
     def process_model(self, model, app_name):
         if 'model' in model:

--- a/suit/tests/templatetags/suit_menu.py
+++ b/suit/tests/templatetags/suit_menu.py
@@ -313,7 +313,7 @@ class SuitMenuTestCase(ModelsTestCaseMixin, UserTestCaseMixin):
         menu = self.make_menu_from_response()
         add_book_url = reverse('admin:%s_book_add' % app_label)
         self.assertEqual(menu[0]['url'], add_book_url)
-        # self.assertEqual(menu[0]['models'][0]['url'], add_book_url)
+        self.assertEqual(menu[0]['models'][0]['url'], add_book_url)
 
     #
     # Tests for old menu config format


### PR DESCRIPTION
Greetings @darklow !

Thanks for lovely package

In Django 2.2 there were some updates to sites framework:
https://github.com/django/django/commit/a9f5652113f0721a7066e359ae28d14692ea3c47

Which led to changed model dict (includes `admin_url` and `add_url` by default).
This breaks with django-suit 0.2.26 because of the way it handles model dictionary in `get_native_model_url`.
In short: it does expect dict _to not return_ `admin_url` and have a fallback for it, but if we do have `admin_url=None` in dict, it uses it.

That ends up with `AttributeError: 'NoneType' object has no attribute 'rstrip'`:

```
# Django 2.1
old_model_dict = {'name': 'Items', 'object_name': 'Item', 'perms': {'add': True, 'change': False, 'delete': False, 'view': False}, 'admin_url': None, 'add_url': '/admin/items/item/add/'}
# Django 2.2
new_model_dict = {'name': 'Items', 'object_name': 'Item', 'perms': {'add': True, 'change': False, 'delete': False, 'view': False}, 'admin_url': None, 'add_url': '/admin/items/item/add/'}

# Piece that breaks
url_parts = self.get_native_model_url(model).rstrip('/').split('/')
```