### PR TITLE
Fix getting admin_url when perm 'change' is missing and django>=2.2

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -353,7 +353,12 @@ class Menu(object):
         }
 
     def get_native_model_url(self, model):
-        return model.get('admin_url', model.get('add_url', ''))
+        # admin_url is present in model with value None by default since django 2.2
+        # https://github.com/django/django/commit/a9f5652113f0721a7066e359ae28d14692ea3c47#diff-57866af2aff590165ffe4967107424fdR435
+        url = model.get('admin_url')
+        if url is None:
+            url = model.get('add_url', '')
+        return url
 
     def process_model(self, model, app_name):
         if 'model' in model:


### PR DESCRIPTION
Since django2.2 admin_url will be present in model dict with default None value and will make suit apply str methods on None.
https://github.com/django/django/commit/a9f5652113f0721a7066e359ae28d14692ea3c47#diff-57866af2aff590165ffe4967107424fdR435

Please note that suit v2 doesn't seem to handle this either:
https://github.com/darklow/django-suit/commit/04b7a141849c51ef22b20009dcf6b2de19437aa8