### PR TITLE
Django 3.0 compatibility for Suit 1.x

### DIFF
--- a/suit/templates/admin/auth/user/change_password.html
+++ b/suit/templates/admin/auth/user/change_password.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify admin_urls %}
+{% load i18n static admin_modify admin_urls %}
 {% load url from suit_compat %}
 
 {% block extrahead %}{{ block.super }}

--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static %}{% load suit_tags %}{% load url from suit_compat %}<!DOCTYPE html>
+{% load static %}{% load suit_tags %}{% load url from suit_compat %}<!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/suit/templates/admin/base_site.html
+++ b/suit/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% load admin_static %}
+{% load static %}
 
 {# Additional <head> content here, some extra meta tags or favicon #}
 {#{% block extrahead %}#}

--- a/suit/templates/admin/change_form.html
+++ b/suit/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify suit_tags admin_urls %}
+{% load i18n static admin_modify suit_tags admin_urls %}
 {% load url from suit_compat %}
 
 {% block extrahead %}{{ block.super }}
@@ -31,13 +31,13 @@
     }(Suit.$))
     </script>
   {% endif %}
-        
+
   <script>
     (function ($) {
       $(function () {
         $("#{% firstof opts.model_name opts.module_name %}_form").suit_form_debounce();
       });
-    }(Suit.$))    
+    }(Suit.$))
   </script>
 
 {% endblock %}

--- a/suit/templates/admin/change_list.html
+++ b/suit/templates/admin/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_list admin_urls suit_list suit_tags %}
+{% load i18n static admin_list admin_urls suit_list suit_tags %}
 {% load url from suit_compat %}
 
 {% block extrastyle %}

--- a/suit/templates/admin/change_list_results.html
+++ b/suit/templates/admin/change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static suit_list %}
+{% load i18n static suit_list %}
 {% if result_hidden_fields %}
     <div class="hiddenfields">{# DIV for HTML validation #}
         {% for item in result_hidden_fields %}{{ item }}{% endfor %}

--- a/suit/templates/admin/edit_inline/stacked.html
+++ b/suit/templates/admin/edit_inline/stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_urls suit_tags %}
+{% load i18n static admin_urls suit_tags %}
 <div class="inline-group {{ inline_admin_formset.opts.suit_classes }}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
 {{ inline_admin_formset.formset.management_form }}

--- a/suit/templates/admin/edit_inline/tabular.html
+++ b/suit/templates/admin/edit_inline/tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_modify suit_tags admin_urls %}
+{% load i18n static admin_modify suit_tags admin_urls %}
 <div class="inline-group {{ inline_admin_formset.opts.suit_classes }}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}

--- a/suit/templates/admin/import_export/base.html
+++ b/suit/templates/admin/import_export/base.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify %}
+{% load i18n static admin_modify %}
 {% load admin_urls %}
 {% load url from suit_compat %}
 

--- a/suit/templates/admin/index.html
+++ b/suit/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block extrastyle %}
   {{ block.super }}

--- a/suit/templates/admin/login.html
+++ b/suit/templates/admin/login.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static suit_tags %}
+{% load i18n static suit_tags %}
 {% load url from suit_compat %}
 
 {% block extrastyle %}{{ block.super }}

--- a/suit/templates/admin/search_form.html
+++ b/suit/templates/admin/search_form.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static suit_list admin_list suit_tags %}
+{% load i18n static suit_list admin_list suit_tags %}
 {% if cl.search_fields or cl.has_filters %}
   {% suit_bc_value 1.5 'pop' 1.6 '_popup' as POPUP_VAR %}
   <div id="toolbar" class="clearfix">

--- a/suit/templates/suit/error_base.html
+++ b/suit/templates/suit/error_base.html
@@ -1,4 +1,4 @@
-{% load admin_static i18n %}{% load url from suit_compat %}<!DOCTYPE html>
+{% load static i18n %}{% load url from suit_compat %}<!DOCTYPE html>
 <!--[if lt IE 9 ]><html lang="en"> <![endif]-->
 <!--[if (gte IE 9)|!(IE)]><!-->
 <html lang="en" xmlns="http://www.w3.org/1999/html"> <!--<![endif]-->

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -10,11 +10,7 @@ except ImportError:
     # For Django >= 2.0
     from django.urls import reverse, resolve
 
-try:
-    from django.utils.six import string_types
-except ImportError:
-    # For Django < 1.4.2
-    string_types = basestring,
+string_types = str,
 
 import re
 import warnings
@@ -46,7 +42,7 @@ def get_menu(context, request):
     else:
         try:
             template_response = get_admin_site(context.current_app).index(request)
-        # Django 1.10 removed the current_app parameter for some classes and functions. 
+        # Django 1.10 removed the current_app parameter for some classes and functions.
         # Check the release notes.
         except AttributeError:
             template_response = get_admin_site(context.request.resolver_match.namespace).index(request)

--- a/suit/tests/widgets.py
+++ b/suit/tests/widgets.py
@@ -3,7 +3,7 @@ from suit.widgets import LinkedSelect, HTML5Input, EnclosedInput, \
     NumberInput, SuitDateWidget, SuitTimeWidget, SuitSplitDateTimeWidget, \
     AutosizedTextarea
 from django.utils.translation import ugettext as _
-from django.contrib.admin.templatetags.static import static
+from django.templatetags.static import static
 from suit import utils
 
 django_version = utils.django_major_version()

--- a/suit/tests/widgets.py
+++ b/suit/tests/widgets.py
@@ -3,7 +3,7 @@ from suit.widgets import LinkedSelect, HTML5Input, EnclosedInput, \
     NumberInput, SuitDateWidget, SuitTimeWidget, SuitSplitDateTimeWidget, \
     AutosizedTextarea
 from django.utils.translation import ugettext as _
-from django.contrib.admin.templatetags.admin_static import static
+from django.contrib.admin.templatetags.static import static
 from suit import utils
 
 django_version = utils.django_major_version()

--- a/suit/widgets.py
+++ b/suit/widgets.py
@@ -3,7 +3,7 @@ from django.forms import TextInput, Select, Textarea
 from django.utils.safestring import mark_safe
 from django import forms
 from django.utils.translation import ugettext as _
-from django.contrib.admin.templatetags.static import static
+from django.templatetags.static import static
 
 from suit import utils
 

--- a/suit/widgets.py
+++ b/suit/widgets.py
@@ -3,7 +3,7 @@ from django.forms import TextInput, Select, Textarea
 from django.utils.safestring import mark_safe
 from django import forms
 from django.utils.translation import ugettext as _
-from django.contrib.admin.templatetags.admin_static import static
+from django.contrib.admin.templatetags.static import static
 
 from suit import utils
 


### PR DESCRIPTION
This is far form the cleanest PR I've ever written, but it does what I need it to do to make Suit 1.x work in my old site that I've just upgraded to Django 3.0. 

There are two things that I think may need to be further cleaned up:

1. The `string_types` thing I did in `suit_menu.py`. There's surely a better way to change that code to make it Python 3 compatible.
2. Further changes having to do with the removal of "admin_static". There's a template tag called `{% admin_static_url %}` that may or may not need to be changed. However, it either isn't used by any templates that my site uses, or it doesn't need to change. Since I didn't know the answer to that, I left it alone.