### PR TITLE
Make django-suit compatible with Django 4.x.x

### DIFF
--- a/suit/admin_filters.py
+++ b/suit/admin_filters.py
@@ -1,5 +1,9 @@
-from django.utils.translation import ugettext_lazy as _
 from django.contrib.admin import FieldListFilter
+import django
+if django.VERSION[0] < 4:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 
 class IsNullFieldListFilter(FieldListFilter):

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -1,5 +1,9 @@
 from copy import deepcopy
-from django.utils.translation import ugettext_lazy as _
+import django
+if django.VERSION[0] < 4:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 
 class ChildItem(object):


### PR DESCRIPTION
In this commit an error:

"django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'suit.templatetags.suit_menu': cannot import name 'ugettext_lazy' from 'django.utils.translation' python3.10/site-packages/django/utils/translation/__init__.py"

has been fixed and now django-suit is compatible with Django  version 4 by importing  the gettext_lazy in admin_filters and menu files