### PR TITLE
Make django-suit compatible with Django 4.x.x

### DIFF
--- a/suit/admin_filters.py
+++ b/suit/admin_filters.py
@@ -1,4 +1,10 @@
-from django.utils.translation import ugettext_lazy as _
+from django import VERSION as django_version
+
+if django_version >= (3, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
+
 from django.contrib.admin import FieldListFilter
 
 

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -1,5 +1,10 @@
 from copy import deepcopy
-from django.utils.translation import ugettext_lazy as _
+from django import VERSION as django_version
+
+if django_version >= (3, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class ChildItem(object):
@@ -170,7 +175,7 @@ class MenuManager(object):
         """
         :type native_model: dict
         """
-        child_item = ChildItem(native_model['name'],  model=native_model.get('model'), url=native_model['admin_url'])
+        child_item = ChildItem(native_model['name'], model=native_model.get('model'), url=native_model['admin_url'])
         return child_item
 
     def handle_parent_menu(self, parent_item, native_app):


### PR DESCRIPTION
In this commit an error:

"django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'suit.templatetags.suit_menu': cannot import name 'ugettext_lazy' from 'django.utils.translation' python3.10/site-packages/django/utils/translation/__init__.py"

has been fixed and now django-suit is compatible with Django  version 4 by importing  the gettext_lazy in admin_filters and menu files